### PR TITLE
Add training package PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ This repository hosts a simple **Delivery Assistant** web app compatible with Gi
 ## Usage
 
 Open `index.html` in a browser or deploy the repository with GitHub Pages. Choose a **voice** from the dropdown (Friendly, Boring Logistics Expert, or Crazy Person), type your question about your delivery, and press **Send**. The assistant will show a **thinking...** animation while waiting for a response.
+
+## Training Package
+
+A printable training guide is available in [training_package.pdf](training_package.pdf). It covers setup, usage, and tips for the Delivery Assistant.

--- a/training_package.pdf
+++ b/training_package.pdf
@@ -1,0 +1,44 @@
+%PDF-1.7
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 269 >>
+stream
+BT
+/F1 12 Tf
+72 720 Td
+(Training Package: Using the Delivery Assistant) Tj
+0 -14 Td
+(1. Open index.html in a browser.) Tj
+0 -14 Td
+(2. Choose a voice and ask about deliveries.) Tj
+0 -14 Td
+(3. The assistant will respond via the backend API.) Tj
+0 -14 Td
+(Enjoy!) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000560 00000 n 
+trailer
+<< /Root 1 0 R /Size 6 >>
+startxref
+630
+%%EOF


### PR DESCRIPTION
## Summary
- add a printable training package in PDF format
- reference the new PDF from the README

## Testing
- `npm test` *(fails: package.json missing)*