### PR TITLE
Add AI tech news summarizer app

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,29 @@
-Test page
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AI News Summarizer</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>AI News Summarizer</h1>
+    </header>
+    <main>
+        <form id="news-form">
+            <label for="voice-select">Select voice:</label>
+            <select id="voice-select">
+                <option value="DRY">DRY</option>
+                <option value="CRAZY">CRAZY</option>
+                <option value="ENGINEER">ENGINEER</option>
+                <option value="BIZ">BIZ</option>
+            </select>
+            <button type="submit">Get Latest News</button>
+        </form>
+        <div id="loading" class="hidden">🤔 Thinking...</div>
+        <div id="response"></div>
+    </main>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,30 @@
+document.getElementById('news-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const voice = document.getElementById('voice-select').value;
+    const loading = document.getElementById('loading');
+    const responseEl = document.getElementById('response');
+
+    loading.style.display = 'block';
+    responseEl.textContent = '';
+
+    try {
+        const res = await fetch('https://anssi-openai-gateway.azurewebsites.net/api/http_trigger', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'x-api-key': 'qQGNldzEhrEKBq8v4HRBRs2eKRgVu27h'
+            },
+            body: JSON.stringify({
+                system_prompt: 'You are a helpful assistant.',
+                user_input: `Summarize the latest tech news focusing on AI in a ${voice} voice.`
+            })
+        });
+        const data = await res.json();
+        responseEl.textContent = data.openai_response || 'No response';
+    } catch (err) {
+        responseEl.textContent = 'Error fetching news.';
+        console.error(err);
+    } finally {
+        loading.style.display = 'none';
+    }
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,66 @@
+body {
+    font-family: Arial, sans-serif;
+    background: linear-gradient(#e8f5e9, #fffde7);
+    color: #333;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    min-height: 100vh;
+}
+
+header {
+    background: #008000;
+    color: #fffde7;
+    width: 100%;
+    padding: 1rem;
+    text-align: center;
+}
+
+main {
+    flex: 1;
+    width: 90%;
+    max-width: 600px;
+    margin-top: 2rem;
+}
+
+form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+button {
+    background: #ffd700;
+    color: #008000;
+    padding: 0.5rem 1rem;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-weight: bold;
+}
+
+#response {
+    margin-top: 1rem;
+    padding: 1rem;
+    background: #fafff0;
+    border: 1px solid #ffd700;
+    border-radius: 4px;
+    white-space: pre-wrap;
+}
+
+#loading {
+    margin-top: 1rem;
+    display: none;
+    font-size: 1.2rem;
+    animation: blink 1s infinite;
+}
+
+@keyframes blink {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.2; }
+}
+
+.hidden {
+    display: none;
+}


### PR DESCRIPTION
## Summary
- add web UI in `index.html` for an AI-powered news summarizer with voice styles
- implement API call logic in `script.js`
- add green and yellow theme with animated loading indicator in `style.css`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684819849ce4832aa8c0cbe4293b6d72